### PR TITLE
FIC-1034 updated openapi spec with additional fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fictioneers-node-sdk",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "fictioneers-node-sdk",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "ISC",
       "dependencies": {
         "node-fetch": "^3.2.1",

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -434,14 +434,14 @@ export interface components {
      */
     TokenResponse: {
       /**
-       * Primary Key
+       * Access Token
        * @description Access Token used to authenticate with Audience APIs.
        * @example ryJhbGciOiJSUzI1NiIsImtpZCI6IjQ7OTQ5ZDdkNDA3ZmVjOXIyYWM4ZDYzNWVjYmEwYjdhOTE0LWQ4ZmIiLCJ0eXAiOiJK
        */
       access_token: string;
       /**
        * Expires In
-       * @description Time in seconds until the ID Token expires.
+       * @description Time in seconds until the Access Token expires.
        * @example 3600
        */
       expires_in: number;
@@ -627,6 +627,18 @@ export interface components {
        */
       related_timeline_event_ids: string[];
       /**
+       * Unlocked By Timeline Event Id
+       * @description This event will be made AVAILABLE once the event in this field is COMPLETED or SKIPPED
+       * @example s1sad1DkWZephtcJDmtM
+       */
+      unlocked_by_timeline_event_id?: string | null;
+      /**
+       * Unlocks Timeline Event Id
+       * @description The event in this field will be made AVAILABLE once this event is COMPLETED or SKIPPED
+       * @example s1sad1DkWZephtcJDmtM
+       */
+      unlocks_timeline_event_id?: string | null;
+      /**
        * Available Step Index
        * @description Identifies the step index in which this event becomes available.
        * @example 1
@@ -729,7 +741,6 @@ export interface components {
       /** Meta */
       meta?: components["schemas"]["Meta"] | null;
     };
-
     /**
      * UserTimelineEventListResponse
      * @description Base serializer class for all list responses, inheriting error and metadata from


### PR DESCRIPTION
**Description**
Updates to the openapi spec generated by branch `1034-linked-events-api-fields` on the main platform repo, this includes the new optional fields `unlocked_by_timeline_event_id` and `unlocks_timeline_event_id`.

Do not publish until `1034-linked-events-api-fields` has been merged on the main repo.