### PR TITLE
fix: Dont reset the access token when a duplicate userID is set.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -119,6 +119,12 @@ class Fictioneers {
    * @param {string} userId
    */
   async setUserId({ userId }: { userId: string }): Promise<void> {
+
+    // If the user ID being set is already the current user ID, do nothing.
+    if (userId === this.userId) {
+      return;
+    }
+
     if (userId.length) {
       this.userId = userId.toString();
       this.accessToken = null;


### PR DESCRIPTION
I found this bug when using the SDK. When calling `setUserId` with a user ID with a duplicate user ID the access token is removed making subsequent calls fail.

This fix adds a check before wiping the access token to ensure the new user ID is unique.